### PR TITLE
feat: workflow version

### DIFF
--- a/.github/workflows/build-module.yml
+++ b/.github/workflows/build-module.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
 
     steps:
       - name: Checkout code
@@ -34,7 +35,7 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Module version: $VERSION"
 
-      - name: Update version in module file (for ZIP only)
+      - name: Update version in module file
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           echo "Updating module version to: $VERSION"
@@ -83,5 +84,27 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           files: module_overtime-${{ steps.version.outputs.version }}.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create PR for version update
+        if: github.event_name == 'release'
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          BRANCH_NAME="chore/bump-version-${VERSION}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git checkout -b "$BRANCH_NAME"
+          git add core/modules/modOvertime.class.php
+          git commit -m "chore: bump version to $VERSION"
+          git push origin "$BRANCH_NAME"
+
+          gh pr create \
+            --title "chore: bump version to $VERSION" \
+            --body "Automatic version bump after release $VERSION" \
+            --base main \
+            --head "$BRANCH_NAME"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-module.yml
+++ b/.github/workflows/build-module.yml
@@ -20,6 +20,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
 
       - name: Get version from release
         id: version


### PR DESCRIPTION
## Summary
- Modifies the GitHub workflow to create a PR for version bump instead of committing directly to main
- Fixes issue with protected main branch by using branch + PR approach
- After a release is created, the workflow now:
  1. Creates a new branch `chore/bump-version-{VERSION}`
  2. Commits the version update
  3. Opens a PR targeting main

## Test plan
- [ ] Create a test release to verify workflow creates PR correctly
- [ ] Verify the PR contains only the version bump commit