### PR TITLE
fix(ci): simplify workflow triggers to main branch only

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,9 +2,9 @@ name: Tests
 
 on:
   push:
-    branches: [ main, develop ]
+    branches: [ main ]
   pull_request:
-    branches: [ main, develop ]
+    branches: [ main ]
 
 jobs:
   unit-tests:


### PR DESCRIPTION
## Summary
- Simplified CI workflow triggers to target only the `main` branch
- Removed `develop` and `improvements` branches from push/pull_request triggers
- Reduces unnecessary workflow runs on development branches

## Test plan
- [ ] Verify workflow runs on push to main
- [ ] Verify workflow runs on PR to main
- [ ] Verify workflow no longer runs on push to develop